### PR TITLE
Add release automation and development tooling

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,123 @@
+name: Update Changelog on Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get tag info
+        id: tag_info
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+          echo "date=$(date +%Y-%m-%d)" >> $GITHUB_OUTPUT
+
+          # Find previous tag
+          PREV_TAG=$(git tag --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+' | sed -n '2p')
+          echo "prev_tag=$PREV_TAG" >> $GITHUB_OUTPUT
+
+      - name: Generate changelog entry
+        id: generate
+        run: |
+          TAG="${{ steps.tag_info.outputs.tag }}"
+          DATE="${{ steps.tag_info.outputs.date }}"
+          PREV_TAG="${{ steps.tag_info.outputs.prev_tag }}"
+
+          # Build commit range
+          if [ -n "$PREV_TAG" ]; then
+            RANGE="${PREV_TAG}..${TAG}"
+          else
+            RANGE="${TAG}"
+          fi
+
+          # Collect commits grouped by type
+          ADDED=""
+          CHANGED=""
+          FIXED=""
+          REMOVED=""
+          OTHER=""
+
+          while IFS= read -r line; do
+            [ -z "$line" ] && continue
+            case "$line" in
+              feat*|add*)    ADDED="${ADDED}- ${line#*: }\n" ;;
+              fix*|bug*)     FIXED="${FIXED}- ${line#*: }\n" ;;
+              remove*|drop*|delete*) REMOVED="${REMOVED}- ${line#*: }\n" ;;
+              refactor*|chore*|perf*|ci*|build*|docs*|style*|test*) CHANGED="${CHANGED}- ${line#*: }\n" ;;
+              *)             OTHER="${OTHER}- ${line}\n" ;;
+            esac
+          done < <(git log "$RANGE" --pretty=format:"%s" --no-merges 2>/dev/null || git log "${TAG}" --pretty=format:"%s" --no-merges)
+
+          # Build the new entry
+          ENTRY="## [${TAG#v}] - ${DATE}\n\n"
+
+          if [ -n "$ADDED" ]; then
+            ENTRY="${ENTRY}### Added\n${ADDED}\n"
+          fi
+          if [ -n "$CHANGED" ]; then
+            ENTRY="${ENTRY}### Changed\n${CHANGED}\n"
+          fi
+          if [ -n "$FIXED" ]; then
+            ENTRY="${ENTRY}### Fixed\n${FIXED}\n"
+          fi
+          if [ -n "$REMOVED" ]; then
+            ENTRY="${ENTRY}### Removed\n${REMOVED}\n"
+          fi
+          if [ -n "$OTHER" ]; then
+            ENTRY="${ENTRY}### Other\n${OTHER}\n"
+          fi
+
+          if [ -z "$ADDED$CHANGED$FIXED$REMOVED$OTHER" ]; then
+            ENTRY="${ENTRY}_(No notable changes recorded)_\n\n"
+          fi
+
+          ENTRY="${ENTRY}---\n"
+
+          # Save to a temp file for the next step
+          printf "%b" "$ENTRY" > /tmp/new_entry.md
+          echo "Generated entry for $TAG"
+
+      - name: Prepend entry to CHANGELOG.md
+        run: |
+          TAG="${{ steps.tag_info.outputs.tag }}"
+
+          # Skip if this version is already in the changelog
+          if grep -q "## \[${TAG#v}\]" CHANGELOG.md 2>/dev/null; then
+            echo "Version ${TAG#v} already present in CHANGELOG.md — skipping."
+            exit 0
+          fi
+
+          # Insert new entry after the first line (the "# Changelog" header)
+          head -1 CHANGELOG.md > /tmp/changelog_new.md
+          echo "" >> /tmp/changelog_new.md
+          cat /tmp/new_entry.md >> /tmp/changelog_new.md
+          tail -n +2 CHANGELOG.md >> /tmp/changelog_new.md
+          mv /tmp/changelog_new.md CHANGELOG.md
+
+      - name: Commit and push updated changelog
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git add CHANGELOG.md
+
+          if git diff --cached --quiet; then
+            echo "No changes to commit."
+            exit 0
+          fi
+
+          git commit -m "docs: update CHANGELOG.md for ${{ steps.tag_info.outputs.tag }}"
+          git push origin HEAD:refs/heads/main

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,60 @@
+.PHONY: help tag tags debug release install clean lint test
+
+# Default target
+help:
+	@echo ""
+	@echo "FireVision IPTV — Available Commands"
+	@echo "======================================"
+	@echo ""
+	@echo "Release Management:"
+	@echo "  make tag VERSION=v1.2.3   Create and push an annotated release tag"
+	@echo "  make tags                 List recent release tags (newest first)"
+	@echo ""
+	@echo "Gradle Shortcuts:"
+	@echo "  make debug                Assemble debug APK"
+	@echo "  make release              Assemble release APK"
+	@echo "  make install              Build debug APK and install via adb"
+	@echo "  make clean                Clean build outputs"
+	@echo "  make lint                 Run Android lint checks"
+	@echo "  make test                 Run unit tests"
+	@echo ""
+
+# ── Release tagging ──────────────────────────────────────────────────────────
+
+tag:
+ifndef VERSION
+	$(error VERSION is required. Usage: make tag VERSION=v1.2.3)
+endif
+	@echo "$(VERSION)" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$$' || \
+		(echo "Error: VERSION must follow semantic versioning: vMAJOR.MINOR.PATCH (e.g. v1.2.3)" && exit 1)
+	@echo "Creating annotated tag $(VERSION)..."
+	git tag -a "$(VERSION)" -m "Release $(VERSION)"
+	git push origin "$(VERSION)"
+	@echo "Tag $(VERSION) created and pushed successfully."
+
+tags:
+	@echo ""
+	@echo "Recent release tags (newest first):"
+	@echo "-------------------------------------"
+	@git tag --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+' | head -20 || echo "(no release tags found)"
+	@echo ""
+
+# ── Gradle shortcuts ─────────────────────────────────────────────────────────
+
+debug:
+	./gradlew assembleDebug
+
+release:
+	./gradlew assembleRelease
+
+install:
+	./gradlew assembleDebug && adb install -r app/build/outputs/apk/debug/app-debug.apk
+
+clean:
+	./gradlew clean
+
+lint:
+	./gradlew lint
+
+test:
+	./gradlew test


### PR DESCRIPTION
## Summary
This PR introduces automated changelog management and development convenience tooling to streamline the release process and improve developer experience.

## Key Changes

- **GitHub Actions Workflow for Changelog Updates** (`.github/workflows/changelog.yml`)
  - Automatically generates and prepends changelog entries when a version tag (v*) is pushed
  - Intelligently categorizes commits by type (Added, Changed, Fixed, Removed, Other) based on conventional commit prefixes
  - Finds the previous release tag and generates a diff-based changelog entry
  - Prevents duplicate entries by checking if a version already exists in CHANGELOG.md
  - Commits and pushes the updated changelog back to the main branch

- **Makefile for Common Tasks** (`Makefile`)
  - Release management commands:
    - `make tag VERSION=v1.2.3` - Creates and pushes annotated semantic version tags with validation
    - `make tags` - Lists recent release tags in reverse chronological order
  - Gradle wrapper shortcuts for common Android development tasks:
    - `make debug` - Assemble debug APK
    - `make release` - Assemble release APK
    - `make install` - Build and install debug APK via adb
    - `make clean` - Clean build outputs
    - `make lint` - Run Android lint checks
    - `make test` - Run unit tests
  - Includes help target documenting all available commands

## Notable Implementation Details

- The changelog workflow uses `fetch-depth: 0` to access full git history for accurate tag comparison
- Commit categorization uses pattern matching on conventional commit prefixes (feat, fix, refactor, etc.)
- The tag command validates semantic versioning format (vMAJOR.MINOR.PATCH) before creating tags
- Graceful fallback in changelog generation if no previous tag exists
- Uses GitHub Actions bot identity for automated commits to maintain clean git history

https://claude.ai/code/session_01DczFhwQkSVXXovvWkjTpJp