### PR TITLE
Improve UI spacing and card sizing for better visual hierarchy

### DIFF
--- a/app/src/main/java/com/cadnative/firevisioniptv/presentation/ui/components/ChannelCard.kt
+++ b/app/src/main/java/com/cadnative/firevisioniptv/presentation/ui/components/ChannelCard.kt
@@ -98,8 +98,8 @@ fun ChannelCard(
 
     Box(
         modifier = modifier
-            .width(200.dp)
-            .height(120.dp)
+            .width(260.dp)
+            .height(150.dp)
     ) {
         // Ambient glow layer (behind the card) — always rendered, alpha drives visibility
         Box(

--- a/app/src/main/java/com/cadnative/firevisioniptv/presentation/ui/screens/CategoriesScreen.kt
+++ b/app/src/main/java/com/cadnative/firevisioniptv/presentation/ui/screens/CategoriesScreen.kt
@@ -101,7 +101,7 @@ fun CategoriesScreen(
                         }
 
                         LazyVerticalGrid(
-                            columns = GridCells.Adaptive(minSize = 200.dp),
+                            columns = GridCells.Adaptive(minSize = 240.dp),
                             modifier = Modifier.fillMaxSize(),
                             contentPadding = PaddingValues(24.dp),
                             horizontalArrangement = Arrangement.spacedBy(16.dp),
@@ -155,7 +155,7 @@ private fun CategoryCard(
         },
         modifier = modifier
             .fillMaxWidth()
-            .height(130.dp)
+            .height(150.dp)
             .graphicsLayer { scaleX = scale; scaleY = scale }
             .onFocusChanged { isFocused = it.isFocused }
             .onKeyEvent { keyEvent ->

--- a/app/src/main/java/com/cadnative/firevisioniptv/presentation/ui/screens/ChannelsScreen.kt
+++ b/app/src/main/java/com/cadnative/firevisioniptv/presentation/ui/screens/ChannelsScreen.kt
@@ -199,11 +199,11 @@ private fun ChannelsGrid(
     modifier: Modifier = Modifier
 ) {
     LazyVerticalGrid(
-        columns = GridCells.Adaptive(minSize = 200.dp),
+        columns = GridCells.Adaptive(minSize = 260.dp),
         modifier = modifier.fillMaxSize(),
         contentPadding = PaddingValues(24.dp),
-        horizontalArrangement = Arrangement.spacedBy(14.dp),
-        verticalArrangement = Arrangement.spacedBy(14.dp)
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
         itemsIndexed(channels, key = { _, channel -> channel.id }) { index, channel ->
             ChannelCard(

--- a/app/src/main/java/com/cadnative/firevisioniptv/presentation/ui/screens/FavoritesScreen.kt
+++ b/app/src/main/java/com/cadnative/firevisioniptv/presentation/ui/screens/FavoritesScreen.kt
@@ -95,11 +95,11 @@ private fun FavoritesGrid(
     modifier: Modifier = Modifier
 ) {
     LazyVerticalGrid(
-        columns = GridCells.Fixed(4),
+        columns = GridCells.Fixed(3),
         modifier = modifier.fillMaxSize(),
         contentPadding = PaddingValues(24.dp),
-        horizontalArrangement = Arrangement.spacedBy(14.dp),
-        verticalArrangement = Arrangement.spacedBy(14.dp)
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
         itemsIndexed(favorites, key = { _, channel -> channel.id }) { index, channel ->
             ChannelCard(

--- a/app/src/main/java/com/cadnative/firevisioniptv/presentation/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/cadnative/firevisioniptv/presentation/ui/screens/HomeScreen.kt
@@ -189,8 +189,8 @@ private fun HeroBanner(
     if (channels.isEmpty()) return
 
     val screenWidth = LocalConfiguration.current.screenWidthDp.dp
-    val cardWidth = (screenWidth * 0.28f).coerceIn(200.dp, 400.dp)
-    val cardHeight = (cardWidth * 0.56f).coerceIn(110.dp, 224.dp)
+    val cardWidth = (screenWidth * 0.35f).coerceIn(280.dp, 500.dp)
+    val cardHeight = (cardWidth * 0.56f).coerceIn(160.dp, 280.dp)
 
     Column(modifier = modifier.padding(horizontal = 40.dp)) {
         Text(
@@ -200,7 +200,7 @@ private fun HeroBanner(
         )
         Spacer(modifier = Modifier.height(20.dp))
         LazyRow(
-            horizontalArrangement = Arrangement.spacedBy(20.dp)
+            horizontalArrangement = Arrangement.spacedBy(24.dp)
         ) {
             items(channels, key = { it.id }) { channel ->
                 ChannelCard(
@@ -261,8 +261,8 @@ private fun PopularCategoryCard(
     Card(
         onClick = onClick,
         modifier = modifier
-            .width(180.dp)
-            .height(100.dp)
+            .width(220.dp)
+            .height(130.dp)
             .graphicsLayer { scaleX = scale; scaleY = scale }
             .onFocusChanged { isFocused = it.isFocused },
         shape = MaterialTheme.shapes.medium,
@@ -391,9 +391,9 @@ private fun ChannelRow(
                 }
             }
         }
-        Spacer(modifier = Modifier.height(14.dp))
+        Spacer(modifier = Modifier.height(16.dp))
         LazyRow(
-            horizontalArrangement = Arrangement.spacedBy(14.dp)
+            horizontalArrangement = Arrangement.spacedBy(18.dp)
         ) {
             items(channels, key = { it.id }) { channel ->
                 ChannelCard(

--- a/app/src/main/java/com/cadnative/firevisioniptv/presentation/ui/screens/SearchScreen.kt
+++ b/app/src/main/java/com/cadnative/firevisioniptv/presentation/ui/screens/SearchScreen.kt
@@ -162,11 +162,11 @@ fun SearchScreen(
                             modifier = Modifier.padding(bottom = 16.dp)
                         )
                         LazyVerticalGrid(
-                            columns = GridCells.Adaptive(minSize = 200.dp),
+                            columns = GridCells.Adaptive(minSize = 260.dp),
                             modifier = Modifier.fillMaxSize(),
                             contentPadding = PaddingValues(bottom = 24.dp),
-                            horizontalArrangement = Arrangement.spacedBy(14.dp),
-                            verticalArrangement = Arrangement.spacedBy(14.dp)
+                            horizontalArrangement = Arrangement.spacedBy(16.dp),
+                            verticalArrangement = Arrangement.spacedBy(16.dp)
                         ) {
                             itemsIndexed(uiState.results, key = { _, channel -> channel.id }) { index, channel ->
                                 ChannelCard(

--- a/app/src/main/res/mipmap-anydpi-v26/ic_banner.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_banner.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
-    <background android:drawable="@color/ic_banner_background"/>
-    <foreground android:drawable="@drawable/ic_banner_foreground"/>
-</adaptive-icon>


### PR DESCRIPTION
## Summary
This PR enhances the visual layout and spacing throughout the app by increasing card sizes, adjusting grid layouts, and improving spacing consistency across multiple screens.

## Key Changes

**Card Sizing Updates:**
- Increased `ChannelCard` dimensions from 200×120dp to 260×150dp for better visibility
- Enlarged `PopularCategoryCard` from 180×100dp to 220×130dp
- Updated `HeroBanner` card width calculation from 28% to 35% of screen width with adjusted constraints (280-500dp)
- Increased `CategoryCard` height from 130dp to 150dp

**Grid Layout Adjustments:**
- Changed `FavoritesScreen` grid from 4 columns to 3 columns for larger card display
- Updated `ChannelsScreen` grid minimum cell size from 200dp to 260dp
- Updated `SearchScreen` grid minimum cell size from 200dp to 260dp
- Updated `CategoriesScreen` grid minimum cell size from 200dp to 240dp

**Spacing Improvements:**
- Standardized horizontal and vertical spacing to 16dp across grids (previously 14dp)
- Increased `HeroBanner` horizontal spacing from 20dp to 24dp
- Increased `ChannelRow` spacing from 14dp to 18dp and vertical spacer from 14dp to 16dp

**Cleanup:**
- Removed unused `ic_banner.xml` adaptive icon resource

## Implementation Details
These changes create a more spacious and visually balanced interface with larger, more prominent cards that are easier to interact with on TV screens. The consistent 16dp spacing across grids provides a unified design language throughout the application.

https://claude.ai/code/session_01Sy5FnuU6AJuQkV7mHdUhFy