### PR TITLE
fix: keep Xtream credentials out of stored stream URLs (URL templating)

### DIFF
--- a/app/src/main/java/com/cadnative/firevisioniptv/FireVisionTvInputService.kt
+++ b/app/src/main/java/com/cadnative/firevisioniptv/FireVisionTvInputService.kt
@@ -13,6 +13,7 @@ import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.ExoPlayer
+import com.cadnative.firevisioniptv.data.source.remote.playlist.StreamUrlTemplate
 import org.json.JSONObject
 
 class FireVisionTvInputService : TvInputService() {
@@ -108,6 +109,7 @@ class FireVisionTvInputService : TvInputService() {
                         val internalData = cursor.getString(0)
                         val json = JSONObject(internalData ?: "{}")
                         json.optString("channelUrl").takeIf { it.isNotEmpty() }
+                            ?.let { StreamUrlTemplate.resolve(ctx, it) }
                     } else null
                 }
             } catch (e: Exception) {

--- a/app/src/main/java/com/cadnative/firevisioniptv/data/source/remote/playlist/StreamUrlTemplate.kt
+++ b/app/src/main/java/com/cadnative/firevisioniptv/data/source/remote/playlist/StreamUrlTemplate.kt
@@ -1,0 +1,23 @@
+package com.cadnative.firevisioniptv.data.source.remote.playlist
+
+import android.content.Context
+import com.cadnative.firevisioniptv.data.AppPreferences
+
+/**
+ * Keeps Xtream credentials out of URLs at rest. Imported stream URLs embed
+ * [USER_TOKEN]/[PASS_TOKEN] placeholders instead of real credentials, so the
+ * Room DB and the TIF provider store credential-free templates. [resolve]
+ * substitutes the tokens from EncryptedSharedPreferences at use time
+ * (playback, probing); non-templated URLs pass through unchanged.
+ */
+object StreamUrlTemplate {
+    const val USER_TOKEN = "{username}"
+    const val PASS_TOKEN = "{password}"
+
+    fun resolve(context: Context, url: String): String {
+        if (!url.contains(USER_TOKEN) && !url.contains(PASS_TOKEN)) return url
+        return url
+            .replace(USER_TOKEN, AppPreferences.getXtreamUser(context))
+            .replace(PASS_TOKEN, AppPreferences.getXtreamPass(context))
+    }
+}

--- a/app/src/main/java/com/cadnative/firevisioniptv/data/source/remote/playlist/XtreamDataSource.kt
+++ b/app/src/main/java/com/cadnative/firevisioniptv/data/source/remote/playlist/XtreamDataSource.kt
@@ -13,7 +13,9 @@ import javax.inject.Singleton
 /**
  * Xtream Codes client. Loads live categories + streams via `player_api.php` and maps
  * them into [ChannelDto]s that reuse the managed-channel pipeline. Live stream URLs
- * follow the standard `/live/{user}/{pass}/{id}.m3u8` form; EPG comes from `xmltv.php`.
+ * follow the standard `/live/{user}/{pass}/{id}.m3u8` form but are stored with
+ * [StreamUrlTemplate] placeholders so credentials never persist in the Room DB;
+ * EPG comes from `xmltv.php`.
  */
 @Singleton
 class XtreamDataSource @Inject constructor(
@@ -41,7 +43,7 @@ class XtreamDataSource @Inject constructor(
             ChannelDto(
                 id = "xtream-${s.streamId}",
                 name = s.name ?: "Channel ${s.streamId}",
-                url = "$base/live/$username/$password/${s.streamId}.m3u8",
+                url = "$base/live/${StreamUrlTemplate.USER_TOKEN}/${StreamUrlTemplate.PASS_TOKEN}/${s.streamId}.m3u8",
                 channelImg = null,
                 tvgLogo = s.streamIcon,
                 groupTitle = categoryNames[s.categoryId] ?: "Uncategorized",

--- a/app/src/main/java/com/cadnative/firevisioniptv/domain/service/ChannelHealthScanner.kt
+++ b/app/src/main/java/com/cadnative/firevisioniptv/domain/service/ChannelHealthScanner.kt
@@ -1,13 +1,16 @@
 package com.cadnative.firevisioniptv.domain.service
 
+import android.content.Context
 import android.util.Log
 import com.cadnative.firevisioniptv.data.source.local.dao.ChannelDao
 import com.cadnative.firevisioniptv.data.source.local.dao.ChannelHealthDao
 import com.cadnative.firevisioniptv.data.source.local.entity.ChannelHealthEntity
+import com.cadnative.firevisioniptv.data.source.remote.playlist.StreamUrlTemplate
 import com.cadnative.firevisioniptv.di.IoDispatcher
 import com.cadnative.firevisioniptv.domain.model.ChannelHealthStatus
 import com.cadnative.firevisioniptv.domain.repository.HealthSyncEntry
 import com.cadnative.firevisioniptv.domain.repository.StreamMetricsRepository
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -39,6 +42,7 @@ data class ScanProgress(
 
 @Singleton
 class ChannelHealthScanner @Inject constructor(
+    @ApplicationContext private val context: Context,
     private val channelHealthDao: ChannelHealthDao,
     private val channelDao: ChannelDao,
     private val thumbnailExtractor: ChannelThumbnailExtractor,
@@ -179,7 +183,7 @@ class ChannelHealthScanner @Inject constructor(
             val channelUrls = withContext(dispatcher) {
                 batch.mapNotNull { id ->
                     val entity = channelDao.getChannelByIdSync(id)
-                    entity?.let { id to it.streamUrl }
+                    entity?.let { id to StreamUrlTemplate.resolve(context, it.streamUrl) }
                 }
             }
             if (channelUrls.isEmpty()) {

--- a/app/src/main/java/com/cadnative/firevisioniptv/domain/service/ChannelThumbnailExtractor.kt
+++ b/app/src/main/java/com/cadnative/firevisioniptv/domain/service/ChannelThumbnailExtractor.kt
@@ -6,6 +6,7 @@ import android.media.MediaMetadataRetriever
 import android.util.Log
 import com.cadnative.firevisioniptv.data.source.local.dao.ChannelDao
 import com.cadnative.firevisioniptv.data.source.local.dao.ChannelHealthDao
+import com.cadnative.firevisioniptv.data.source.remote.playlist.StreamUrlTemplate
 import com.cadnative.firevisioniptv.di.IoDispatcher
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineDispatcher
@@ -70,7 +71,7 @@ class ChannelThumbnailExtractor @Inject constructor(
         for (batch in batches) {
             val channelUrls = withContext(dispatcher) {
                 batch.mapNotNull { id ->
-                    channelDao.getChannelByIdSync(id)?.let { id to it.streamUrl }
+                    channelDao.getChannelByIdSync(id)?.let { id to StreamUrlTemplate.resolve(context, it.streamUrl) }
                 }
             }
 

--- a/app/src/main/java/com/cadnative/firevisioniptv/presentation/ui/screens/MultiviewScreen.kt
+++ b/app/src/main/java/com/cadnative/firevisioniptv/presentation/ui/screens/MultiviewScreen.kt
@@ -41,12 +41,14 @@ import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.media3.common.MediaItem
 import androidx.media3.exoplayer.ExoPlayer
+import com.cadnative.firevisioniptv.data.source.remote.playlist.StreamUrlTemplate
 import com.cadnative.firevisioniptv.domain.model.Channel
 import com.cadnative.firevisioniptv.presentation.ui.screens.player.VideoPlayer
 import com.cadnative.firevisioniptv.presentation.ui.theme.Amber
@@ -237,6 +239,7 @@ private fun MultiviewPane(
     modifier: Modifier = Modifier
 ) {
     val shape = RoundedCornerShape(6.dp)
+    val context = LocalContext.current
     val focusRequester = remember { FocusRequester() }
     if (requestInitialFocus) {
         LaunchedEffect(Unit) { runCatching { focusRequester.requestFocus() } }
@@ -247,7 +250,9 @@ private fun MultiviewPane(
     val player = remember(channel.id) { viewModel.createPlayer() }
     DisposableEffect(channel.id) {
         channel.streamUrl?.let { url ->
-            player.setMediaItem(MediaItem.Builder().setUri(url).build())
+            player.setMediaItem(
+                MediaItem.Builder().setUri(StreamUrlTemplate.resolve(context, url)).build()
+            )
             player.prepare()
             player.playWhenReady = true
         }

--- a/app/src/main/java/com/cadnative/firevisioniptv/presentation/ui/screens/player/PlayerScreenEffects.kt
+++ b/app/src/main/java/com/cadnative/firevisioniptv/presentation/ui/screens/player/PlayerScreenEffects.kt
@@ -18,6 +18,7 @@ import androidx.media3.ui.PlayerView
 import com.cadnative.firevisioniptv.ComposeMainActivity
 import com.cadnative.firevisioniptv.PipController
 import com.cadnative.firevisioniptv.data.AppPreferences
+import com.cadnative.firevisioniptv.data.source.remote.playlist.StreamUrlTemplate
 import com.cadnative.firevisioniptv.presentation.model.ChannelUiModel
 import com.cadnative.firevisioniptv.presentation.ui.player.ErrorRecoveryManager
 import com.cadnative.firevisioniptv.presentation.ui.player.isTvDevice
@@ -38,7 +39,7 @@ internal fun prepareChannelStream(
     catchupStartMs: Long,
     catchupDurationMin: Int
 ): Boolean {
-    val url = channel.streamUrl
+    val url = channel.streamUrl?.let { StreamUrlTemplate.resolve(context, it) }
     if (url.isNullOrEmpty()) return false
     errorRecoveryManager.reset()
 

--- a/app/src/test/java/com/cadnative/firevisioniptv/domain/service/ChannelHealthScannerTest.kt
+++ b/app/src/test/java/com/cadnative/firevisioniptv/domain/service/ChannelHealthScannerTest.kt
@@ -31,6 +31,7 @@ class ChannelHealthScannerTest {
     fun setup() {
         Dispatchers.setMain(testDispatcher)
         scanner = ChannelHealthScanner(
+            context = mockk(relaxed = true),
             channelHealthDao = mockk(relaxed = true),
             channelDao = mockk(relaxed = true),
             thumbnailExtractor = mockk(relaxed = true),


### PR DESCRIPTION
## Summary
Closes #50 — the residual finding from the #49 security review. Xtream live URLs (`/live/{user}/{pass}/{id}.m3u8`) embed credentials by protocol and were persisted verbatim in the Room DB and TIF provider data.

Imported stream URLs now store `{username}`/`{password}` placeholder tokens instead of real credentials. The new `StreamUrlTemplate` resolver substitutes them from `EncryptedSharedPreferences` at use time. Non-templated URLs (M3U, paired server) pass through unchanged.

## Consumers threaded
- **PlayerScreenEffects** — live playback resolves before building stream slots (proxy URLs get the resolved form)
- **MultiviewScreen** — per-pane players resolve at `setMediaItem`
- **FireVisionTvInputService** — resolves at tune time; `ChannelManager` now writes the credential-free template into `TvContract`, so credentials also stop leaking into the system TV database
- **ChannelHealthScanner** — resolves before probing (`@ApplicationContext` now injected; unit test updated)
- **ChannelThumbnailExtractor** — resolves before HLS manifest fetches

Existing installs self-heal on the next channel sync: `refreshChannels()` rewrites all Room rows from the templated import, and the TIF sync rewrites provider data.

## On-device verification (Android TV emulator, API 34, mock Xtream panel with auth-gated HLS)
- **Room DB**: all channels store `.../live/{username}/{password}/{id}.m3u8`; byte-level scan of DB + WAL found zero credential occurrences
- **Live playback**: stream renders; server log shows the resolved credentialed request arriving at request time
- **Multiview**: two panes streaming concurrently, both manifests fetched with resolved credentials
- **TIF**: sync inserts the 4 channels into `TvContract` (rows receive the templated `streamUrl` verbatim); input service registered
- **Health scanner**: background probe hit never-played channels with resolved credentials
- `./gradlew assembleDebug` + unit tests pass; pre-commit lint passes

## Residual
- System-TV tune-in (`FireVisionTvInputService.resolve()` at playback) could not be exercised on the emulator (no Live Channels app) — worth a quick spot check on a real Fire TV. It is the same one-line resolve verified in the other consumers.
- The EPG URL (`xmltv.php?username=&password=`) is inherent to the Xtream protocol and out of scope per the issue.