### PR TITLE
fix: make player menu reachable on remotes without a MENU button

### DIFF
--- a/app/src/main/java/com/cadnative/firevisioniptv/data/AppPreferences.kt
+++ b/app/src/main/java/com/cadnative/firevisioniptv/data/AppPreferences.kt
@@ -12,7 +12,6 @@ object AppPreferences {
     private const val SERVER_URL_KEY = "server_url"
     private const val TV_CODE_KEY = "tv_code"
     private const val DEMO_MODE_KEY = "is_demo_mode"
-    private const val PLAYER_HINT_COUNT_KEY = "player_hint_count"
     private const val EPG_XMLTV_URL_KEY = "epg_xmltv_url"
     private const val PLAYLIST_EPG_URL_KEY = "playlist_epg_url"
     private const val PLAYLIST_SOURCE_TYPE_KEY = "playlist_source_type"
@@ -26,7 +25,6 @@ object AppPreferences {
     const val SOURCE_PAIRED = "paired"
     const val SOURCE_M3U = "m3u"
     const val SOURCE_XTREAM = "xtream"
-    const val PLAYER_HINT_MAX_SHOWS = 3
 
     fun getServerUrl(context: Context): String {
         val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
@@ -74,16 +72,6 @@ object AppPreferences {
             .putBoolean(DEMO_MODE_KEY, true)
             .putString(PLAYLIST_SOURCE_TYPE_KEY, SOURCE_PAIRED)
             .apply()
-    }
-
-    fun getPlayerHintCount(context: Context): Int {
-        val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-        return prefs.getInt(PLAYER_HINT_COUNT_KEY, 0)
-    }
-
-    fun incrementPlayerHintCount(context: Context) {
-        val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-        prefs.edit().putInt(PLAYER_HINT_COUNT_KEY, getPlayerHintCount(context) + 1).apply()
     }
 
     /**

--- a/app/src/main/java/com/cadnative/firevisioniptv/data/repository/UserPreferencesRepositoryImpl.kt
+++ b/app/src/main/java/com/cadnative/firevisioniptv/data/repository/UserPreferencesRepositoryImpl.kt
@@ -33,7 +33,9 @@ class UserPreferencesRepositoryImpl @Inject constructor(
     private val _layoutDensity = MutableStateFlow(prefs.getString(KEY_LAYOUT_DENSITY, "comfortable") ?: "comfortable")
     private val _backExitProtection = MutableStateFlow(prefs.getBoolean(KEY_BACK_EXIT_PROTECTION, true))
     private val _keyUpDownAction = MutableStateFlow(prefs.getString(KEY_PLAYER_KEY_UP_DOWN, PlayerKeyAction.ZAP) ?: PlayerKeyAction.ZAP)
-    private val _keyLeftRightAction = MutableStateFlow(prefs.getString(KEY_PLAYER_KEY_LEFT_RIGHT, PlayerKeyAction.ZAP) ?: PlayerKeyAction.ZAP)
+    // ◀▶ defaults to the player menu: it otherwise duplicates ▲▼ zap, and remotes
+    // without a MENU button (Google TV) would have no way to reach audio/subtitles.
+    private val _keyLeftRightAction = MutableStateFlow(prefs.getString(KEY_PLAYER_KEY_LEFT_RIGHT, PlayerKeyAction.MENU) ?: PlayerKeyAction.MENU)
     private val _longOkAction = MutableStateFlow(prefs.getString(KEY_PLAYER_LONG_OK, PlayerKeyAction.FAVORITE) ?: PlayerKeyAction.FAVORITE)
     private val _sleepTimerDefaultMinutes = MutableStateFlow(prefs.getInt(KEY_SLEEP_TIMER_DEFAULT, 0))
     private val _alwaysShowProgramBar = MutableStateFlow(prefs.getBoolean(KEY_ALWAYS_SHOW_PROGRAM_BAR, false))

--- a/app/src/main/java/com/cadnative/firevisioniptv/domain/repository/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/cadnative/firevisioniptv/domain/repository/UserPreferencesRepository.kt
@@ -147,4 +147,5 @@ object PlayerKeyAction {
     const val LAST_CHANNEL = "last_channel"
     const val FAVORITE = "favorite"
     const val PLAY_PAUSE = "play_pause"
+    const val MENU = "menu"
 }

--- a/app/src/main/java/com/cadnative/firevisioniptv/presentation/ui/screens/PlayerScreen.kt
+++ b/app/src/main/java/com/cadnative/firevisioniptv/presentation/ui/screens/PlayerScreen.kt
@@ -176,8 +176,9 @@ fun PlayerScreen(
                 viewModel.onStreamDead("Invalid stream URL")
                 return@let
             }
-            // Reveal transient chrome on every zap / channel entry
-            overlayState.revealControls()
+            // Zap / channel entry reveals the info bar; control chrome only on
+            // mobile — the TV quick-actions bar shows only when summoned
+            if (isMobile) overlayState.revealControls()
             overlayState.revealInfoBar()
         }
     }
@@ -203,7 +204,6 @@ fun PlayerScreen(
     // Auto-hide timers for the transient overlays
     PlayerOverlayTimers(
         state = overlayState,
-        isMobile = isMobile,
         infoBarTimeoutMs = uiState.infoBarTimeoutSeconds * 1000L,
         onCommitChannelNumber = { viewModel.switchToChannelNumber(it) }
     )

--- a/app/src/main/java/com/cadnative/firevisioniptv/presentation/ui/screens/player/PlayerKeyHandler.kt
+++ b/app/src/main/java/com/cadnative/firevisioniptv/presentation/ui/screens/player/PlayerKeyHandler.kt
@@ -40,6 +40,9 @@ internal fun performKeyAction(
             state.revealControls()
         }
         PlayerKeyAction.PLAY_PAUSE -> togglePlayPause(exoPlayer, state)
+        // Same as the MENU key — many Android TV remotes have no MENU button,
+        // so this must be reachable via a remappable D-pad key.
+        PlayerKeyAction.MENU -> state.focusQuickActions()
     }
 }
 

--- a/app/src/main/java/com/cadnative/firevisioniptv/presentation/ui/screens/player/PlayerOverlayState.kt
+++ b/app/src/main/java/com/cadnative/firevisioniptv/presentation/ui/screens/player/PlayerOverlayState.kt
@@ -8,14 +8,11 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.platform.LocalContext
-import com.cadnative.firevisioniptv.data.AppPreferences
 import kotlinx.coroutines.delay
 
 private const val CONTROLS_AUTO_HIDE_MS = 5000L
 private const val FAV_INDICATOR_DURATION_MS = 2000L
 private const val NUMBER_COMMIT_MS = 2000L
-private const val KEY_HINT_DURATION_MS = 4000L
 private const val PLAY_PAUSE_FLASH_MS = 800L
 private const val GESTURE_INDICATOR_HIDE_MS = 700L
 private const val ZAP_OVERLAY_HIDE_MS = 1500L
@@ -32,13 +29,14 @@ internal data class GestureIndicator(val type: GestureIndicatorType, val level: 
  */
 @Stable
 internal class PlayerOverlayState {
-    var controlsReveal by mutableIntStateOf(1)
+    // Starts hidden: on TV the quick-actions bar appears only when summoned
+    // (MENU / ◀▶); mobile reveals its chrome on channel load.
+    var controlsReveal by mutableIntStateOf(0)
     var favIndicatorToken by mutableIntStateOf(0)
     var infoBarReveal by mutableIntStateOf(0)
     var playPauseFlashToken by mutableIntStateOf(0)
     var playPauseFlashPlaying by mutableStateOf(true)
     var numberBuffer by mutableStateOf("")
-    var showKeyHints by mutableStateOf(false)
     var controlsFocused by mutableStateOf(false)          // derived from bar onFocusChanged
     var controlsFocusRequest by mutableIntStateOf(0)      // >0 → bar claims D-pad focus
 
@@ -107,12 +105,9 @@ internal fun rememberPlayerOverlayState(): PlayerOverlayState = remember { Playe
 @Composable
 internal fun PlayerOverlayTimers(
     state: PlayerOverlayState,
-    isMobile: Boolean,
     infoBarTimeoutMs: Long,
     onCommitChannelNumber: (Int) -> Unit
 ) {
-    val context = LocalContext.current
-
     // Suspended while the quick-actions bar has focus; focus loss restarts a full timeout
     LaunchedEffect(state.controlsReveal, state.controlsFocused) {
         if (state.controlsReveal > 0 && !state.controlsFocused) {
@@ -164,15 +159,6 @@ internal fun PlayerOverlayTimers(
             delay(NUMBER_COMMIT_MS)
             state.numberBuffer.toIntOrNull()?.let(onCommitChannelNumber)
             state.numberBuffer = ""
-        }
-    }
-    // One-line key hints on the first few launches (TV only)
-    LaunchedEffect(Unit) {
-        if (!isMobile && AppPreferences.getPlayerHintCount(context) < AppPreferences.PLAYER_HINT_MAX_SHOWS) {
-            AppPreferences.incrementPlayerHintCount(context)
-            state.showKeyHints = true
-            delay(KEY_HINT_DURATION_MS)
-            state.showKeyHints = false
         }
     }
 }

--- a/app/src/main/java/com/cadnative/firevisioniptv/presentation/ui/screens/player/PlayerOverlays.kt
+++ b/app/src/main/java/com/cadnative/firevisioniptv/presentation/ui/screens/player/PlayerOverlays.kt
@@ -82,8 +82,6 @@ internal fun BoxScope.PlayerOverlays(
     val fullInfoBarVisible = state.showInfoBar && canShowInfoBar
     val pinnedInfoBarVisible = alwaysShowInfoBar && !state.showInfoBar && canShowInfoBar
     val infoBarVisible = fullInfoBarVisible || pinnedInfoBarVisible
-    // Keep bottom-center toasts above the info bar when both are on screen
-    val toastBottomPadding = if (infoBarVisible) 96.dp else 32.dp
 
     // Now/next info bar — revealed on zap or INFO key, auto-hides
     AnimatedVisibility(
@@ -201,18 +199,6 @@ internal fun BoxScope.PlayerOverlays(
                 .background(ScrimLight)
                 .padding(horizontal = 20.dp, vertical = 6.dp)
         )
-    }
-
-    // Key hints — bottom-center on the first few launches
-    AnimatedVisibility(
-        visible = state.showKeyHints && !uiState.showChannelOverlay,
-        enter = fadeIn(tween(DURATION_NORMAL, easing = EaseOutQuart)),
-        exit = fadeOut(tween(DURATION_EXIT, easing = EaseOutQuart)),
-        modifier = Modifier
-            .align(Alignment.BottomCenter)
-            .padding(bottom = toastBottomPadding)
-    ) {
-        OverlayToast("OK: channels   ▲▼ ◀▶: zap   MENU: options   Hold OK: favorite   ⏪: last ch   0-9: channel #")
     }
 
     // Live quick-actions bar (TV) — bottom-left, auto-hides with the other

--- a/app/src/main/java/com/cadnative/firevisioniptv/presentation/ui/screens/player/PlayerQuickActions.kt
+++ b/app/src/main/java/com/cadnative/firevisioniptv/presentation/ui/screens/player/PlayerQuickActions.kt
@@ -54,8 +54,10 @@ internal fun nextSleepTimerStep(current: Int?): Int? {
 
 /**
  * Live-player quick-actions bar: favorite toggle, sleep-timer cycler, and
- * open-channel-list. Summoned + focused via MENU on TV (see PlayerKeyHandler);
- * ◀▶ move between buttons, OK activates, ▲/BACK/MENU exit back to the player.
+ * open-channel-list. Summoned + focused via MENU or ◀▶ on TV (see
+ * PlayerKeyHandler — ◀▶ maps to the "menu" action by default since Google TV
+ * remotes lack a MENU button); once focused, ◀▶ move between buttons, OK
+ * activates, ▲/BACK/MENU exit back to the player.
  *
  * Live-appropriate only — no scrub/seek/speed. The sleep timer cycles through
  * preset durations (Off → 30 → 60 → 90 → 120 → Off); every action is a single

--- a/app/src/main/java/com/cadnative/firevisioniptv/presentation/ui/screens/settings/ControlsSection.kt
+++ b/app/src/main/java/com/cadnative/firevisioniptv/presentation/ui/screens/settings/ControlsSection.kt
@@ -20,7 +20,8 @@ private val keyActionOptions = listOf(
     "Zap" to PlayerKeyAction.ZAP,
     "Last Ch" to PlayerKeyAction.LAST_CHANNEL,
     "Favorite" to PlayerKeyAction.FAVORITE,
-    "Play/Pause" to PlayerKeyAction.PLAY_PAUSE
+    "Play/Pause" to PlayerKeyAction.PLAY_PAUSE,
+    "Menu" to PlayerKeyAction.MENU
 )
 
 private val sleepTimerOptions = listOf(


### PR DESCRIPTION
## Problem

On Android TV / Google TV the audio & subtitle panel could never be opened: the quick-actions bar (which holds the **Audio/Subs** button) was only summoned by the MENU key, and those remotes don't have one. Fire TV's ☰ button was the only way in.

Separately, the quick-actions bar auto-popped over the video on every player entry and zap, and a one-line key-hints toast showed on the first launches — both flagged as bad UX.

## Changes

- **New "Menu" remappable key action** that summons + focuses the quick-actions bar, same as the MENU key. Selectable for D-pad up/down, left/right, and Hold OK in Settings → Player Controls.
- **D-pad ◀▶ now defaults to Menu** — it previously duplicated the ▲▼ zap action, so nothing is lost. Users who explicitly picked "Zap" for left/right keep their saved setting.
- **Quick-actions bar no longer auto-shows on TV** on player entry or zap; it appears only when summoned. Mobile keeps its tap-to-show chrome; the now/next info bar is unchanged.
- **Removed the first-launch key-hints toast** and its `AppPreferences` hint-count plumbing.

## Testing

- `./gradlew assembleDebug` passes; pre-commit Android lint passes.
- To verify on a box: enter the player → only the info bar shows; press ◀ or ▶ → quick-actions bar gains focus → **Audio/Subs** opens the subtitle/audio track panel; Fire TV MENU button behaves the same as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)